### PR TITLE
fix a bug about total steps calculation by epoch nums.

### DIFF
--- a/nanoT5/utils/model_utils.py
+++ b/nanoT5/utils/model_utils.py
@@ -199,7 +199,7 @@ def get_dataloaders(tokenizer, config, args):
 
         if args.optim.epochs > 0:
             assert not is_iterable
-            args.optim.total_steps = int(len(dataloaders['train']) * args.optim.epochs / args.optim.grad_acc)
+            args.optim.total_steps = len(dataloaders['train']) * args.optim.epochs // args.optim.grad_acc
 
         # We increase eval BS by 2, so decrease number of eval steps
         args.eval.corrected_steps = args.eval.steps / 2

--- a/nanoT5/utils/model_utils.py
+++ b/nanoT5/utils/model_utils.py
@@ -199,7 +199,7 @@ def get_dataloaders(tokenizer, config, args):
 
         if args.optim.epochs > 0:
             assert not is_iterable
-            args.optim.total_steps = len(dataloaders['train']) * args.optim.epochs
+            args.optim.total_steps = int(len(dataloaders['train']) * args.optim.epochs / args.optim.grad_acc)
 
         # We increase eval BS by 2, so decrease number of eval steps
         args.eval.corrected_steps = args.eval.steps / 2


### PR DESCRIPTION
If we set `optim.epochs > 0`,  it will overwrite the `optim.total_steps`. However, if we also set `optim.grad_acc > 1` at the same time, the gradient will be accumulated every `optim.grad_acc` batches, and the trainable parameters will also be updated every `optim.grad_acc` batches, then the `args.current_train_step` will be added `1` in `train()` function. So the real/actual total training step should be `int(len(dataloaders['train']) * args.optim.epochs / args.optim.grad_acc)`.